### PR TITLE
Updated jcenter to HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <repository>
             <id>bintray</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
     <scm>


### PR DESCRIPTION
Since January 13th, JCenter is no longer available through HTTP. In stead, you have to use HTTPS. This likely solves #163, since Dependabot is using the `<repositories>` in your `pom.xml` to check for new versions.